### PR TITLE
Add ability to work without internet connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ build/debcvescan
 debcvescan.code-workspace
 debcvescan
 debcvelist.json
-debcvescan.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ cover.out
 gosec_report.*
 dist
 build/debcvescan
+debcvescan.code-workspace
+debcvescan
+debcvelist.json
+debcvescan.code-workspace

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -21,11 +21,6 @@ var downloadCmd = &cobra.Command{
 	Long:  `Download cve json file.`,
 	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		// file, err := os.Create("./debcvelist.json")
-		// if err != nil {
-		// 	panic(err)
-		// }
-
 		client := &http.Client{}
 		req, err := http.NewRequest("GET", "https://security-tracker.debian.org/tracker/data/json", nil)
 		if err != nil {

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// initializes arguments for pkg commmand
+func init() {
+	rootCmd.AddCommand(downloadCmd)
+
+}
+
+// download command
+var downloadCmd = &cobra.Command{
+	Use:   "download",
+	Short: "Download json",
+	Long:  `Download cve json file.`,
+	Args:  cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		// file, err := os.Create("./debcvelist.json")
+		// if err != nil {
+		// 	panic(err)
+		// }
+
+		client := &http.Client{}
+		req, err := http.NewRequest("GET", "https://security-tracker.debian.org/tracker/data/json", nil)
+		if err != nil {
+			panic(err)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			panic(err)
+		}
+
+		defer resp.Body.Close()
+
+		json, err := io.ReadAll(resp.Body)
+		if err != nil {
+			panic(err)
+		}
+
+		err = os.WriteFile("./debcvelist.json", json, 0664)
+		if err != nil {
+			panic(err)
+		}
+
+	},
+}


### PR DESCRIPTION
Added command download which get actual version of known vulnerabilities of the Debian Security Bug Tracker and save as debcvelist.json. 
So deploy to host debcvescan binary and debcvelist.json 
Executed with scan command, debcvescan first tryes get downloaded list and if absent, tryes to download as usual